### PR TITLE
Adds Phoenix.Param implementation

### DIFF
--- a/lib/type_id/phoenix_param.ex
+++ b/lib/type_id/phoenix_param.ex
@@ -1,0 +1,3 @@
+defimpl Phoenix.Param, for: TypeID do
+  def to_param(type_id), do: TypeID.to_string(type_id)
+end


### PR DESCRIPTION
If not implemented, you can stumble upon this kind when using TypeID:
```** (ArgumentError) structs expect an :id key when converting to_param or a custom implementation of the Phoenix.Param protocol (read Phoenix.Param docs for more information), got: #TypeID<"booking_01h8xpqbz6f1p97w7rgqe5bvxh">```