### PR TITLE
Make deps available in all environments

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,10 +43,10 @@ defmodule TypeID.MixProject do
 
   defp deps do
     [
-      {:ecto, "~> 3.10", only: [:dev, :test], optional: true},
-      {:phoenix_html, "~> 3.3", only: [:dev, :test], optional: true},
-      {:phoenix, "~> 1.7", only: [:dev, :test], optional: true},
-      {:jason, "~> 1.4", only: [:dev, :test], optional: true},
+      {:ecto, "~> 3.10", optional: true},
+      {:phoenix_html, "~> 3.3", optional: true},
+      {:phoenix, "~> 1.7", optional: true},
+      {:jason, "~> 1.4", optional: true},
       {:ex_doc, "~> 0.27", only: :dev, runtime: false},
       {:yaml_elixir, "~> 2.9", only: [:dev, :test], runtime: false}
     ]


### PR DESCRIPTION
## Motivations

We are getting compilation errors after typeid was added to our project.

## Proposed solution

The error seems to be caused by `if Code.ensure_loaded?(Ecto.ParameterizedType) do`

Not always the dep is available to typeid in compilation. 

If we continue to mark it as optional, but allow in all environments we can compile without warnings.
