### PR TITLE
allow binary type

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ TypeIDs as fields in your Ecto schemas.
 defmodule MyApp.Accounts.User do
   use Ecto.Schema
 
-  @primary_key {:id, TypeID, autogenerate: true, prefix: "acct", type: :binary_id}
+  @primary_key {:id, TypeID, autogenerate: true, prefix: "acct", type: :binary}
   @foreign_key_type TypeID
 
   # ...
@@ -40,9 +40,11 @@ end
 
 ### Underlying types
 
-`TypeID`s can be stored as either `:string` or `:binary_id`. `:string` will
-store the entire TypeID including the prefix. `:binary_id` stores only the
-UUID portion and requires a `:uuid` or `:binary` column.
+`TypeID`s can be stored as `:string`, `:binary_id`, or `:binary`. `:string` will
+store the entire TypeID including the prefix. `:binary` and `:binary_id` store
+only the UUID portion and require a `:uuid` or `:binary` column. `:binary_id`
+will use UUIDv4 (non K-sortable), whereas `:binary` will use UUIDv7, so
+`:binary` is recommended over `:binary_id` for that reason.
 
 #### Default type
 
@@ -50,5 +52,5 @@ The type used can be set globally in the application config.
 
 ```elixir
 config :typeid_elixir,
-  default_type: :binary_id
+  default_type: :binary
 ```

--- a/README.md
+++ b/README.md
@@ -40,11 +40,9 @@ end
 
 ### Underlying types
 
-`TypeID`s can be stored as `:string`, `:binary_id`, or `:binary`. `:string` will
-store the entire TypeID including the prefix. `:binary` and `:binary_id` store
-only the UUID portion and require a `:uuid` or `:binary` column. `:binary_id`
-will use UUIDv4 (non K-sortable), whereas `:binary` will use UUIDv7, so
-`:binary` is recommended over `:binary_id` for that reason.
+`TypeID`s can be stored as either `:string` or `:binary`. `:string` will store
+the entire TypeID including the prefix. `:binary` stores only the UUID portion
+and requires a `:uuid` or `:binary` column.
 
 #### Default type
 

--- a/lib/type_id/ecto.ex
+++ b/lib/type_id/ecto.ex
@@ -49,6 +49,7 @@ if Code.ensure_loaded?(Ecto.ParameterizedType) do
       case {tid.prefix, type} do
         {^prefix, :string} -> {:ok, TypeID.to_string(tid)}
         {^prefix, :binary_id} -> {:ok, TypeID.uuid(tid)}
+        {^prefix, :binary} -> {:ok, TypeID.uuid_bytes(tid)}
         _ -> :error
       end
     end
@@ -66,12 +67,12 @@ if Code.ensure_loaded?(Ecto.ParameterizedType) do
       end
     end
 
-    def load(<<_::128>> = uuid, _, %{type: :binary_id} = params) do
+    def load(<<_::128>> = uuid, _, %{type: type} = params) when type in [:binary_id, :binary] do
       prefix = find_prefix(params)
       TypeID.from_uuid_bytes(prefix, uuid)
     end
 
-    def load(<<_::288>> = uuid, _, %{type: :binary_id} = params) do
+    def load(<<_::288>> = uuid, _, %{type: type} = params) when type in [:binary_id, :binary] do
       prefix = find_prefix(params)
       TypeID.from_uuid(prefix, uuid)
     rescue
@@ -95,8 +96,8 @@ if Code.ensure_loaded?(Ecto.ParameterizedType) do
         end
       end
 
-      unless type in ~w[string binary_id]a do
-        raise ArgumentError, "`type` must be `:string` or `:binary_id`"
+      unless type in ~w[string binary_id binary]a do
+        raise ArgumentError, "`type` must be `:string`, `:binary_id`, or `:binary`"
       end
 
       if primary_key do

--- a/lib/type_id/ecto.ex
+++ b/lib/type_id/ecto.ex
@@ -48,7 +48,6 @@ if Code.ensure_loaded?(Ecto.ParameterizedType) do
 
       case {tid.prefix, type} do
         {^prefix, :string} -> {:ok, TypeID.to_string(tid)}
-        {^prefix, :binary_id} -> {:ok, TypeID.uuid(tid)}
         {^prefix, :binary} -> {:ok, TypeID.uuid_bytes(tid)}
         _ -> :error
       end
@@ -67,12 +66,12 @@ if Code.ensure_loaded?(Ecto.ParameterizedType) do
       end
     end
 
-    def load(<<_::128>> = uuid, _, %{type: type} = params) when type in [:binary_id, :binary] do
+    def load(<<_::128>> = uuid, _, %{type: :binary} = params) do
       prefix = find_prefix(params)
       TypeID.from_uuid_bytes(prefix, uuid)
     end
 
-    def load(<<_::288>> = uuid, _, %{type: type} = params) when type in [:binary_id, :binary] do
+    def load(<<_::288>> = uuid, _, %{type: :binary} = params) do
       prefix = find_prefix(params)
       TypeID.from_uuid(prefix, uuid)
     rescue
@@ -96,8 +95,8 @@ if Code.ensure_loaded?(Ecto.ParameterizedType) do
         end
       end
 
-      unless type in ~w[string binary_id binary]a do
-        raise ArgumentError, "`type` must be `:string`, `:binary_id`, or `:binary`"
+      unless type in ~w[string binary]a do
+        raise ArgumentError, "`type` must be `:string` or `:binary`"
       end
 
       if primary_key do


### PR DESCRIPTION
Thanks for taking the time to create this library! I'm using it in a project I'm working on, and I noticed the behavior reported in #31 where calling `TypeID.new/1` would generate K-sorted IDs, but letting Ecto autogenerate them would not. Because of that I dug into EctoSQL to understand it's behavior a little better, and came across this:

https://github.com/elixir-ecto/ecto_sql/blob/b1f7386c6465d78e1e09691ed11fa4ad5e854fcd/lib/ecto/adapters/sql.ex#L187

Basically if a parameterized type uses `:binary_id` as the underlying type, EctoSQL will autogenerate it using its own autogenerate implementation rather than the autogenerate method of the custom type.

I debated a little bit about whether to try changing EctoSQL to allow autogenerating a custom type with binary_id underlying it, but it seems like `:binary_id` is a special construct meant just for that library's UUID creation, and really what TypeID cares about is what the underlying storage type is. And since that's the case, I fail to see any reason why `:binary_id` should be used over `:binary`. So this pull request updates the library to allow `:binary` as well, and when I switched all my IDs from `:binary_id` to `:binary` they started autogenerating in a K-sortable way again.

I tried to keep this pull request as simple as possible, but I would recommend that the `:binary_id` type be removed completely in favor of `:binary`. Because the library is still pre-v1.0 I think it would be acceptable to make that change with a minor version bump. Otherwise a deprecation warning could be added for `:binary_id` usage in `TypeID.Ecto.validate_opts!/1` and the functionality could be removed later. I'm happy to make that change in this pull request as well if you would like, but I didn't think it was my place to make that decision without input.