### PR TITLE
Fix prefix validation in Ecto type

### DIFF
--- a/lib/type_id.ex
+++ b/lib/type_id.ex
@@ -263,7 +263,7 @@ defmodule TypeID do
     ArgumentError -> :error
   end
 
-  defp validate_prefix!(prefix) do
+  def validate_prefix!(prefix) do
     cond do
       String.starts_with?(prefix, "_") ->
         invalid_prefix!(prefix, "cannot start with an underscore")

--- a/lib/type_id/ecto.ex
+++ b/lib/type_id/ecto.ex
@@ -89,10 +89,7 @@ if Code.ensure_loaded?(Ecto.ParameterizedType) do
       prefix = Keyword.get(opts, :prefix)
 
       if primary_key do
-        unless prefix && prefix =~ ~r/^[a-z]{0,63}$/ do
-          raise ArgumentError,
-                "must specify `prefix` using only lowercase letters between 0 and 63 characters long."
-        end
+        TypeID.validate_prefix!(prefix)
       end
 
       unless type in ~w[string binary]a do


### PR DESCRIPTION
The prefix validation in the Ecto Type is different to the prefix validation in the TypeID module. This pull request shares the TypeID prefix validation with the Ecto type.