### PR TITLE
fix: handle non-primary-key, non-assoc fields

### DIFF
--- a/lib/type_id/ecto.ex
+++ b/lib/type_id/ecto.ex
@@ -114,11 +114,11 @@ if Code.ensure_loaded?(Ecto.ParameterizedType) do
       if primary_key do
         %{primary_key: primary_key, schema: schema, field: field, prefix: prefix, type: type}
       else
-        %{schema: schema, field: field, type: type}
+        %{schema: schema, field: field, type: type, prefix: prefix}
       end
     end
 
-    defp find_prefix(%{prefix: prefix}), do: prefix
+    defp find_prefix(%{prefix: prefix}) when not is_nil(prefix), do: prefix
 
     defp find_prefix(%{schema: schema, field: field}) do
       %{related: schema, related_key: field} = schema.__schema__(:association, field)


### PR DESCRIPTION
Following up on #37, I believe this solves the problem for regular fields which are not keys. The proposed solution is to always store a `:prefix` in the result of `validate_opts!`, even when it's `nil`. So for assocs `prefix` is going to be `nil`, and for regular fields it's going to store the actual vakue.

 Inside `find_prefix`, we use the stored `:prefix` if it's not `nil` (in case of primary keys and non-key fields), otherwise, (assocs)  we fetch the prefix in the associated module's schema.

I'm just not sure it doesn't break any existing use.